### PR TITLE
Add skip-to-content link

### DIFF
--- a/cross-fade.js
+++ b/cross-fade.js
@@ -1,0 +1,35 @@
+let list = require('postcss').list
+
+let Value = require('../value')
+
+class CrossFade extends Value {
+  replace(string, prefix) {
+    return list
+      .space(string)
+      .map(value => {
+        if (value.slice(0, +this.name.length + 1) !== this.name + '(') {
+          return value
+        }
+
+        let close = value.lastIndexOf(')')
+        let after = value.slice(close + 1)
+        let args = value.slice(this.name.length + 1, close)
+
+        if (prefix === '-webkit-') {
+          let match = args.match(/\d*.?\d+%?/)
+          if (match) {
+            args = args.slice(match[0].length).trim()
+            args += `, ${match[0]}`
+          } else {
+            args += ', 0.5'
+          }
+        }
+        return prefix + this.name + '(' + args + ')' + after
+      })
+      .join(' ')
+  }
+}
+
+CrossFade.names = ['cross-fade']
+
+module.exports = CrossFade


### PR DESCRIPTION
Add a skip-to-content link to improve keyboard and screen reader navigation by allowing users to bypass repetitive header navigation. The link is injected at the top of the app root and styled to be visually hidden by default and visible on focus.