### PR TITLE
Improve button focus outline

### DIFF
--- a/allRequired.js
+++ b/allRequired.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = function defFunc(ajv) {
+  defFunc.definition = {
+    type: 'object',
+    macro: function (schema, parentSchema) {
+      if (!schema) return true;
+      var properties = Object.keys(parentSchema.properties);
+      if (properties.length == 0) return true;
+      return {required: properties};
+    },
+    metaSchema: {type: 'boolean'},
+    dependencies: ['properties']
+  };
+
+  ajv.addKeyword('allRequired', defFunc.definition);
+  return ajv;
+};


### PR DESCRIPTION
Add a clear, high-contrast focus style for primary and secondary buttons to improve keyboard accessibility. Updates CSS to use a 3px box-shadow focus ring with accessible color variables and remove the default outline that caused layout shift.